### PR TITLE
Fixes i18Find() on meteor 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Developed by <a href="http://www.meteorspark.com"><img src="http://www.meteorspa
 **Step 1:** Install tap-i18n-db:
 
 ```bash
-$ meteor add tap:i18n-db
+$ meteor add phowat:i18n-db
 ```
 
 **Step 2:** Initialize the collection you wish to translate with `new TAPi18n.Collection`

--- a/package.js
+++ b/package.js
@@ -1,8 +1,8 @@
 Package.describe({
-  name: 'tap:i18n-db',
-  summary: 'Internationalization for Meteor Collections',
-  version: '0.4.0',
-  git: 'https://github.com/TAPevents/tap-i18n-db'
+  name: 'phowat:i18n-db',
+  summary: 'Internationalization for Meteor Collections. Forked from tap:i18n-db',
+  version: '0.4.1',
+  git: 'https://github.com/phowat/tap-i18n-db'
 });
 
 Package.on_use(function (api) {

--- a/tap_i18n_db-common.coffee
+++ b/tap_i18n_db-common.coffee
@@ -47,7 +47,8 @@ commonCollectionExtensions = (obj) ->
     throwError new Meteor.Error(400, "TAPi18n is not supported"), attempted_operation, callback
 
   isSupportedLanguage = (lang, attempted_operation, callback) ->
-    if lang in TAPi18n.conf.supported_languages
+    supported_languages = TAPi18n.conf.supported_languages || Object.keys TAPi18n.getLanguages()
+    if lang in supported_languages
       return
 
     throwError new Meteor.Error(400, "Not supported language: #{lang}"), attempted_operation, callback

--- a/tap_i18n_db-server.coffee
+++ b/tap_i18n_db-server.coffee
@@ -13,7 +13,7 @@ share.i18nCollectionExtensions = (obj) ->
     dialect_of = share.helpers.dialectOf current_language
     collection_base_language = @._base_language
 
-    supported_languages = TAPi18n.conf.supported_languages
+    supported_languages = TAPi18n.conf.supported_languages || Object.keys TAPi18n.getLanguages()
     if current_language? and not (current_language in supported_languages)
       throw new Meteor.Error(400, "Not supported language")
 


### PR DESCRIPTION
I experienced the same issue described in TAPevents/tap-i18n-db#19 after updating to Meteor 1.2 . Looking into the issue, I noticed it failed because conf.supported_languages was null. Since getLanguages() worked in the same context, I added that. 
