### PR TITLE
Fix use of deprecated API in package.js

### DIFF
--- a/package.js
+++ b/package.js
@@ -1,12 +1,12 @@
 Package.describe({
   name: 'tap:i18n-db',
   summary: 'Internationalization for Meteor Collections',
-  version: '0.4.0',
+  version: '0.4.1',
   git: 'https://github.com/TAPevents/tap-i18n-db'
 });
 
 Package.on_use(function (api) {
-  api.versionsFrom('METEOR@0.9.1');
+  api.versionsFrom('METEOR@1.0.0');
 
   api.use(["coffeescript", "underscore", "meteor", "jquery", "reactive-dict"], ['server', 'client']);
 
@@ -17,8 +17,8 @@ Package.on_use(function (api) {
 
   api.use('yogiben:admin@1.1.0', {weak: true});
 
-  api.add_files('globals.js', ['client', 'server']);
-  api.add_files('tap_i18n_db-common.coffee', ['client', 'server']);
-  api.add_files('tap_i18n_db-server.coffee', 'server');
-  api.add_files('tap_i18n_db-client.coffee', 'client');
+  api.addFiles('globals.js', ['client', 'server']);
+  api.addFiles('tap_i18n_db-common.coffee', ['client', 'server']);
+  api.addFiles('tap_i18n_db-server.coffee', 'server');
+  api.addFiles('tap_i18n_db-client.coffee', 'client');
 });


### PR DESCRIPTION
Fixes use of deprecated API in `package.js` which has been finally removed in Meteor 2.3